### PR TITLE
[SYAL-2409] Reverting to the last recent selected input source when user selects unsupported one.

### DIFF
--- a/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/SamsungMDCDevice.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/SamsungMDCDevice.java
@@ -18,7 +18,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.collections.CollectionUtils;
 
-import com.avispl.symphony.api.common.error.NotImplementedException;
 import com.avispl.symphony.api.dal.control.Controller;
 import com.avispl.symphony.api.dal.dto.control.AdvancedControllableProperty;
 import com.avispl.symphony.api.dal.dto.control.ControllableProperty;
@@ -103,8 +102,8 @@ public class SamsungMDCDevice extends SocketCommunicator implements Controller, 
 
         this.deviceId = 0;
 
-        this.setCommandSuccessList(Collections.singletonList("A"));
-        this.setCommandErrorList(Collections.singletonList("ERROR"));
+        this.setCommandSuccessList(Collections.singletonList(""));
+        this.setCommandErrorList(Collections.singletonList(""));
         this.loadProperties(this.versionProperties);
         this.logger.info(Constant.INITIALIZED_SUCCESSFULLY_INFO);
     }
@@ -149,21 +148,24 @@ public class SamsungMDCDevice extends SocketCommunicator implements Controller, 
 
     @Override
     public void controlProperty(ControllableProperty controllableProperty) throws Exception {
-        if (controllableProperty.getProperty().equals(GeneralProperty.POWER.getName())) {
-            if (controllableProperty.getValue().toString().equals("1")) {
-                powerON();
-            } else if (controllableProperty.getValue().toString().equals("0")) {
-                powerOFF();
+        this.reentrantLock.lock();
+        try {
+            if (controllableProperty.getProperty().equals(GeneralProperty.POWER.getName())) {
+                if (controllableProperty.getValue().toString().equals("1")) {
+                    powerON();
+                } else if (controllableProperty.getValue().toString().equals("0")) {
+                    powerOFF();
+                }
+            } else if (controllableProperty.getProperty().equals(GeneralProperty.INPUT.getName())) {
+                InputSource updatedInput = InputSource.getByName(controllableProperty.getValue().toString());
+                byte[] req = Util.buildSendString((byte) this.deviceId, Command.INPUT_SOURCE.getCode(), new byte[] { updatedInput.getCode() });
+                byte[] res = this.send(req);
+                if (this.digestResponse(res, Command.INPUT_SOURCE).equals(InputSource.UNDEFINED)) {
+                    throw new UnsupportedOperationException(String.format(Constant.SET_INPUT_FAILED, controllableProperty.getValue()));
+                }
             }
-        } else if (controllableProperty.getProperty().equals(GeneralProperty.INPUT.getName())) {
-            InputSource input = InputSource.getByName(controllableProperty.getValue().toString());
-            byte[] req = Util.buildSendString((byte) this.deviceId, Command.INPUT_SOURCE.getCode(), new byte[] { input.getCode() });
-            byte[] res = this.send(req);
-            if (this.digestResponse(res, Command.INPUT_SOURCE).equals(InputSource.UNDEFINED)) {
-                throw new NotImplementedException(String.format(Constant.SET_INPUT_FAILED, input.getName()));
-            }
-        } else {
-            this.logger.warn(Constant.CONTROL_PROPERTY_FAILED + controllableProperty.getProperty());
+        } finally {
+            this.reentrantLock.unlock();
         }
     }
 
@@ -284,6 +286,10 @@ public class SamsungMDCDevice extends SocketCommunicator implements Controller, 
         statistics.put(
             String.format(Constant.PROPERTY_FORMAT, Constant.ADAPTER_METADATA_GROUP, AdapterMetadataProperty.ADAPTER_UPTIME.getName()),
             Util.mapToAdapterMetadataProperty(this.versionProperties, AdapterMetadataProperty.ADAPTER_UPTIME)
+        );
+        statistics.put(
+            String.format(Constant.PROPERTY_FORMAT, Constant.ADAPTER_METADATA_GROUP, AdapterMetadataProperty.ADAPTER_UPTIME_MIN.getName()),
+            Util.mapToAdapterMetadataProperty(this.versionProperties, AdapterMetadataProperty.ADAPTER_UPTIME_MIN)
         );
         statistics.put(
             String.format(Constant.PROPERTY_FORMAT, Constant.ADAPTER_METADATA_GROUP, AdapterMetadataProperty.ADAPTER_VERSION.getName()),

--- a/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/common/Constant.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/common/Constant.java
@@ -23,14 +23,10 @@ public class Constant {
   //	Values
   public static final byte COMMAND_HEADER = (byte) 0xAA;
   public static final String NOT_AVAILABLE = "N/A";
-  public static final String NONE = "None";
   public static final String ON = "On";
   public static final String OFF = "Off";
-  public static final char ACK = 'A';
-  public static final char NAK = 'N';
 
   //	Groups
-  public static final String GENERAL_GROUP = "General";
   public static final String ADAPTER_METADATA_GROUP = "AdapterMetadata";
 
   //  Info messages
@@ -51,7 +47,8 @@ public class Constant {
   public static final String SET_UP_DATA_FAILED_1 = "Failed to set up data for ";
   public static final String SET_UP_DATA_FAILED_2 = "Failed to set up data for some reasons, returning the empty list";
   public static final String SET_UP_DATA_FAILED_3 = "Failed to set up data for some reasons, returning the false value";
-  public static final String MAP_ELAPSED_TIME_FAILED = "Failed to mapToElapsedTime with uptime: ";
+  public static final String MAP_TO_UPTIME_FAILED = "Failed to mapToUptime with uptime: ";
+  public static final String MAP_TO_UPTIME_MIN_FAILED = "Failed to mapToUptimeMin with uptime: ";
   public static final String CONTROL_PROPERTY_FAILED = "Failed to control property: ";
-  public static final String SET_INPUT_FAILED = "Failed to set input source %s, may be it's not supported";
+  public static final String SET_INPUT_FAILED = "Failed to change the input source because the selected value %s is not supported.";
 }

--- a/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/common/Util.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/common/Util.java
@@ -173,6 +173,8 @@ public class Util {
                 return mapToValue(adapterBuildDate);
             case ADAPTER_UPTIME:
                 return mapToUptime(adapterUptime);
+            case ADAPTER_UPTIME_MIN:
+                return mapToUptimeMin(adapterUptime);
             case ADAPTER_VERSION:
                 return mapToValue(adapterVersion);
             default:
@@ -224,9 +226,34 @@ public class Util {
 
             return rs.toString().trim();
         } catch (Exception e) {
-            LOGGER.error(Constant.MAP_ELAPSED_TIME_FAILED + uptime, e);
+            LOGGER.error(Constant.MAP_TO_UPTIME_FAILED + uptime, e);
             return Constant.NOT_AVAILABLE;
         }
     }
 
+    /**
+     * Returns the elapsed uptime in **whole minutes** between the current system time and the given timestamp in milliseconds.
+     * <p>
+     * The input timestamp represents the start time in milliseconds (typically from {@link System#currentTimeMillis()}).
+     * The returned string is the total number of minutes that have elapsed, excluding seconds.
+     *
+     * @param uptime the start time in milliseconds as a string (e.g., "1717581000000")
+     * @return a string representing the total number of elapsed minutes (e.g., "125"),
+     * or {@link Constant#NOT_AVAILABLE} if parsing fails
+     */
+    private static String mapToUptimeMin(String uptime) {
+        try {
+            if (StringUtils.isNullOrEmpty(uptime)) {
+                return Constant.NOT_AVAILABLE;
+            }
+
+            long uptimeSecond = (System.currentTimeMillis() - Long.parseLong(uptime)) / 1000;
+            long minutes = uptimeSecond / 60;
+
+            return String.valueOf(minutes);
+        } catch (Exception e) {
+            LOGGER.error(Constant.MAP_TO_UPTIME_MIN_FAILED + uptime, e);
+            return Constant.NOT_AVAILABLE;
+        }
+    }
 }

--- a/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/types/InputSource.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/types/InputSource.java
@@ -103,7 +103,7 @@ public enum InputSource {
 	public static String[] getNames() {
 		return Arrays.stream(values())
 				.filter(inputSource -> !inputSource.equals(UNDEFINED))
-				.map(inputSource -> inputSource.name).toArray(String[]::new);
+				.map(inputSource -> inputSource.name).sorted().toArray(String[]::new);
 	}
 }
 

--- a/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/types/properties/AdapterMetadataProperty.java
+++ b/src/main/java/com/avispl/symphony/dal/communicator/samsung/mdc/types/properties/AdapterMetadataProperty.java
@@ -9,6 +9,7 @@ package com.avispl.symphony.dal.communicator.samsung.mdc.types.properties;
 public enum AdapterMetadataProperty {
 	ADAPTER_BUILD_DATE("AdapterBuildDate"),
 	ADAPTER_UPTIME("AdapterUptime"),
+	ADAPTER_UPTIME_MIN("AdapterUptime(min)"),
 	ADAPTER_VERSION("AdapterVersion");
 
 	private final String name;

--- a/src/test/java/com/avispl/symphony/dal/communicator/samsung/mdc/SamsungMDCCommunicatorTest.java
+++ b/src/test/java/com/avispl/symphony/dal/communicator/samsung/mdc/SamsungMDCCommunicatorTest.java
@@ -56,7 +56,7 @@ class SamsungMDCCommunicatorTest {
 	}
 
 	@Test
-	void testControlInput() throws Exception {
+	void testControlInputWithSupportedInput() throws Exception {
 		this.extendedStatistics = (ExtendedStatistics) this.communicator.getMultipleStatistics().get(0);
 
 		ControllableProperty controllableProperty = new ControllableProperty();
@@ -70,5 +70,22 @@ class SamsungMDCCommunicatorTest {
 
 		Assertions.assertNotNull(comparedControllableProperty, "ComparedControllableProperty is null");
 		Assertions.assertEquals(controllableProperty.getValue(), comparedControllableProperty.getValue(), "ComparedControllableProperty have unexpected value");
+	}
+
+	@Test
+	void testControlInputWithUnsupportedInput() throws Exception {
+		this.extendedStatistics = (ExtendedStatistics) this.communicator.getMultipleStatistics().get(0);
+		InputSource currentInput = InputSource.getByName(this.extendedStatistics.getStatistics().get(GeneralProperty.INPUT.getName()));
+
+		ControllableProperty controllableProperty = new ControllableProperty();
+		controllableProperty.setProperty(GeneralProperty.INPUT.getName());
+		controllableProperty.setValue(InputSource.AV1_AV.getName());
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> this.communicator.controlProperty(controllableProperty));
+
+		this.extendedStatistics = (ExtendedStatistics) this.communicator.getMultipleStatistics().get(0);
+		AdvancedControllableProperty comparedControllableProperty = this.extendedStatistics.getControllableProperties().stream()
+				.filter(property -> property.getName().equals(GeneralProperty.INPUT.getName())).findFirst().orElse(null);
+		Assertions.assertNotNull(comparedControllableProperty, "ComparedControllableProperty is null");
+		Assertions.assertEquals(currentInput.getName(), comparedControllableProperty.getValue(), "ComparedControllableProperty have unexpected value");
 	}
 }


### PR DESCRIPTION
- Description:
  + Add the AdapterUptime(min) property to the AdapterMetadata group.
     <img width="592" height="279" alt="image" src="https://github.com/user-attachments/assets/7f23f1b0-236f-489b-8ed4-6c24ad67ae9c" />

  + Sort the list of Input Source options in alphabetical order.
     <img width="587" height="853" alt="image" src="https://github.com/user-attachments/assets/3a8e8db0-565f-4877-adb9-104e9da7d5da" />

  + Display an error message when the user selects an unsupported input source.
     <img width="604" height="436" alt="image" src="https://github.com/user-attachments/assets/2eb20ec2-0987-4721-b4e4-f3c7b4b56e11" />

- Note: Review and merge [the pr 38](https://github.com/AVISPL/dal-avdevices-monitors-samsung-mdc/pull/38) first